### PR TITLE
Fix: ARM64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ RUN apt-get update && \
 # Download and install jacksum and s5cmd
 RUN curl -L -O 'https://s3.waw3-2.cloudferro.com/swift/v1/jacksum/jacksum_1.7.0-4.1_all.deb' && \
     dpkg -i jacksum_1.7.0-4.1_all.deb && rm jacksum_1.7.0-4.1_all.deb && \
-    curl -L -O 'https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_linux_amd64.deb' && \
-    dpkg -i s5cmd_2.2.2_linux_amd64.deb && rm s5cmd_2.2.2_linux_amd64.deb
+    # Detect architecture (amd64 or arm64)
+    ARCH=$(dpkg --print-architecture) && \
+    # Use double quotes below so ${ARCH} is expanded
+    curl -L -O "https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_linux_${ARCH}.deb" && \
+    dpkg -i "s5cmd_2.2.2_linux_${ARCH}.deb" && \
+    rm "s5cmd_2.2.2_linux_${ARCH}.deb"
 
 # Copy and set permissions for scripts
 COPY COG2GRD.sh /bin/COG2GRD.sh


### PR DESCRIPTION
The current Dockerfile hardcodes the s5cmd download to amd64, causing build failures on ARM-based systems (failed on my Mac).

This PR replaces the hardcoded URL with dynamic architecture detection using dpkg --print-architecture. This ensures the correct .deb is downloaded for both amd64 and arm64 platforms.

Testing: Verified successful build on Apple M1 (ARM64).