### PR TITLE
Add SH Batch V2 Grid Builder to the utilities repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,23 @@ RUN curl -L -O 'https://s3.waw3-2.cloudferro.com/swift/v1/jacksum/jacksum_1.7.0-
     dpkg -i "s5cmd_2.2.2_linux_${ARCH}.deb" && \
     rm "s5cmd_2.2.2_linux_${ARCH}.deb"
 
+# Use UV as a package manager for Python dependencies
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN uv venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install SH-Batch-Grid-Builder
+RUN uv pip install --no-cache sh-batch-grid-builder
+
 # Copy and set permissions for scripts
 COPY COG2GRD.sh /bin/COG2GRD.sh
 COPY GRD2COG.sh /bin/GRD2COG.sh
 COPY sentinel1_burst_extractor.sh /bin/sentinel1_burst_extractor.sh
 COPY sentinel1_burst_extractor_spatiotemporal.sh /bin/sentinel1_burst_extractor_spatiotemporal.sh
+COPY sh_grid_builder.sh /bin/sh_grid_builder.sh
 
-RUN chmod +x /bin/COG2GRD.sh /bin/GRD2COG.sh /bin/sentinel1_burst_extractor.sh /bin/sentinel1_burst_extractor_spatiotemporal.sh
+RUN chmod +x /bin/COG2GRD.sh /bin/GRD2COG.sh /bin/sentinel1_burst_extractor.sh /bin/sentinel1_burst_extractor_spatiotemporal.sh /bin/sh_grid_builder.sh
 
 # Set environment variables
 ENV AWS_S3_ENDPOINT=eodata.dataspace.copernicus.eu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ RUN apt-get update && \
 # Download and install jacksum and s5cmd
 RUN curl -L -O 'https://s3.waw3-2.cloudferro.com/swift/v1/jacksum/jacksum_1.7.0-4.1_all.deb' && \
     dpkg -i jacksum_1.7.0-4.1_all.deb && rm jacksum_1.7.0-4.1_all.deb && \
-    curl -L -O 'https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_linux_amd64.deb' && \
-    dpkg -i s5cmd_2.2.2_linux_amd64.deb && rm s5cmd_2.2.2_linux_amd64.deb
+    # Detect architecture (amd64 or arm64)
+    ARCH=$(dpkg --print-architecture) && \
+    # Use double quotes below so ${ARCH} is expanded
+    curl -L -O "https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_linux_${ARCH}.deb" && \
+    dpkg -i "s5cmd_2.2.2_linux_${ARCH}.deb" && \
+    rm "s5cmd_2.2.2_linux_${ARCH}.deb"
 
 # Copy and set permissions for scripts
 COPY COG2GRD.sh /bin/COG2GRD.sh

--- a/README.md
+++ b/README.md
@@ -43,3 +43,45 @@ docker run -it -v /home/ubuntu:/home/ubuntu cdse_utilities GRD2COG.sh -i /home/u
 ```
 docker run -it -v /home/ubuntu:/home/ubuntu cdse_utilities COG2COG.sh -i /home/ubuntu/docker_test/S1A_IW_GRDH_1SDV_20230206T165050_20230206T165115_047118_05A716_1A19_COG.SAFE.zip -o /home/ubuntu
 ```
+
+## Generate a custom grid aligned to the native projection grid for use in Sentinel Hub Batch V2 API
+
+This utility generates aligned geometries (bounding box or a pixelated AOI) following the requirements of [Sentinel Hub Batch V2 API](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/BatchV2.html) for an input AOI. It wraps the [sh-batch-grid-builder](https://pypi.org/project/sh-batch-grid-builder/) Python package.
+
+### Script Options                                                         
+
+```bash
+-i: path to input AOI file (GeoJSON, GPKG, or other formats supported by GeoPandas)
+
+-r: grid resolution as "(x,y)" or "x,y" in CRS coordinate units (e.g., "10,10" for 10 meters)
+
+-p: EPSG code for the output CRS (e.g., 3035 for ETRS89 / LAEA Europe, 4326 for WGS84)
+
+-t: output type: bounding-box or pixelated
+
+-o: path to output file (GPKG format required)
+
+-h: help
+
+-v: version
+```
+### Usage examples
+Generate aligned bounding box with same resolution for x and y:
+```
+docker run -it -v "$(pwd)":/home/ubuntu cdse_utilities sh_grid_builder.sh -i /home/ubuntu/aoi.geojson -r "10,10" -p 3035 -t bounding-box -o /home/ubuntu/output_bbox.gpkg
+```
+
+Generate aligned bounding box with different x and y resolutions:
+```
+docker run -it -v "$(pwd)":/home/ubuntu cdse_utilities sh_grid_builder.sh -i /home/ubuntu/aoi.geojson -r "(300,359)" -p 32632 -t bounding-box -o /home/ubuntu/output_bbox.gpkg
+```
+
+Generate pixelated geometry:
+```
+docker run -it -v "$(pwd)":/home/ubuntu cdse_utilities sh_grid_builder.sh -i /home/ubuntu/aoi.geojson -r "10,10" -p 3035 -t pixelated -o /home/ubuntu/output_pixelated.gpkg
+```
+
+Example with geographic CRS (degrees):
+```
+docker run -it -v "$(pwd)":/home/ubuntu cdse_utilities sh_grid_builder.sh -i /home/ubuntu/aoi.geojson -r "(0.001,0.001)" -p 4326 -t bounding-box -o /home/ubuntu/output_bbox.gpkg
+```

--- a/sh_grid_builder.sh
+++ b/sh_grid_builder.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Example of usage
+#./sh_grid_builder.sh -i data/aoi.geojson -r "10,10" -p 3035 -t bounding-box -o output_bbox.gpkg
+#./sh_grid_builder.sh -i data/aoi.geojson -r "(300,359)" -p 32632 -t pixelated -o output_pixelated.gpkg
+#developed by CloudFerro
+#contact jmusial(at)cloudferro.com
+###############################
+#release notes:
+#Version 1.0 [20260124] - initial release
+version="1.0"
+usage()
+{
+cat << EOF
+#usage: $0 options
+This utility generates projection grid aligned bounding boxes and pixelated geometries
+from AOI (Area of Interest) files for Sentinel Hub Batch V2 API on CDSE.
+It wraps the sh-batch-grid-builder Python package.
+
+OPTIONS:
+   -p      EPSG code for the output CRS (e.g., 3035 for ETRS89 / LAEA Europe, 4326 for WGS84)
+   -h      help message
+   -i      path to input AOI file (GeoJSON, GPKG, or other formats supported by GeoPandas)
+   -o      path to output file (GPKG format required)
+   -r      grid resolution as "(x,y)" or "x,y" in CRS coordinate units (e.g., "10,10" for 10 meters)
+   -t      output type: bounding-box or pixelated
+   -v      version
+
+EXAMPLES:
+   # Generate aligned bounding box with same resolution for x and y
+   $0 -i aoi.geojson -r "10,10" -p 3035 -t bounding-box -o output_bbox.gpkg
+
+   # Generate aligned bounding box with different x and y resolutions
+   $0 -i aoi.geojson -r "(300,359)" -p 32632 -t bounding-box -o output_bbox.gpkg
+
+   # Generate pixelated geometry
+   $0 -i aoi.geojson -r "10,10" -p 3035 -t pixelated -o output_pixelated.gpkg
+
+   # Example with geographic CRS (degrees)
+   $0 -i aoi.geojson -r "(0.001,0.001)" -p 4326 -t bounding-box -o output_bbox.gpkg
+
+EOF
+}
+
+while getopts "hp:i:o:r:t:v" OPTION; do
+	case $OPTION in
+		p)
+			epsg=$OPTARG
+			;;
+		h)
+			usage
+			exit 0
+			;;
+		i)
+			input_aoi=$OPTARG
+			;;
+		o)
+			output=$OPTARG
+			;;
+		r)
+			resolution=$OPTARG
+			;;
+		t)
+			output_type=$OPTARG
+			;;
+		v)
+			echo sh_grid_builder version $version
+			exit 0
+			;;
+		?)
+			usage
+			exit 1
+			;;
+	esac
+done
+
+if [ -z $(which sh-grid-builder) ]; then
+	echo "ERROR: sh-grid-builder not found. Please install it: pip install sh-batch-grid-builder" && exit 2
+fi
+
+if [ -z "$input_aoi" ]; then
+	echo "ERROR: Input AOI file not specified" && exit 3
+fi
+
+if [ ! -f "$input_aoi" ]; then
+	echo "ERROR: Input AOI file '$input_aoi' does not exist" && exit 4
+fi
+
+if [ -z "$resolution" ]; then
+	echo "ERROR: Resolution not specified" && exit 3
+fi
+
+if [ -z "$epsg" ]; then
+	echo "ERROR: EPSG code not specified" && exit 3
+fi
+
+if [ -z "$output_type" ]; then
+	echo "ERROR: Output type not specified" && exit 3
+fi
+
+if [ "$output_type" != "bounding-box" -a "$output_type" != "pixelated" ]; then
+	echo "ERROR: Output type '$output_type' not valid. Must be 'bounding-box' or 'pixelated'" && exit 3
+fi
+
+if [ -z "$output" ]; then
+	echo "ERROR: Output file not specified" && exit 3
+fi
+
+sh-grid-builder "$input_aoi" --resolution "$resolution" --epsg $epsg --output-type $output_type -o "$output"

--- a/sh_grid_builder.sh
+++ b/sh_grid_builder.sh
@@ -2,12 +2,9 @@
 # Example of usage
 #./sh_grid_builder.sh -i data/aoi.geojson -r "10,10" -p 3035 -t bounding-box -o output_bbox.gpkg
 #./sh_grid_builder.sh -i data/aoi.geojson -r "(300,359)" -p 32632 -t pixelated -o output_pixelated.gpkg
-#developed by CloudFerro
-#contact jmusial(at)cloudferro.com
+#developed by Maxim Lamare (2026)
 ###############################
-#release notes:
-#Version 1.0 [20260124] - initial release
-version="1.0"
+version="0.2.2"
 usage()
 {
 cat << EOF


### PR DESCRIPTION
I have added an additional script to the utilities repository in order to run the Sentinel Hub Batch Grid Builder.

To do so, I have:

- added the `sh` command line utility
- updated the repository
- updated the Docker file (using uv as a Python package manager)

Please note the previous Pull Request for the Docker compatibility with Mac.

@j-musial 

cc @gmilcinski 